### PR TITLE
changing line 55 to use ARRaycastManager

### DIFF
--- a/Assets/Demo/ARTapToPlaceObject.cs
+++ b/Assets/Demo/ARTapToPlaceObject.cs
@@ -52,7 +52,7 @@ public class ARTapToPlaceObject : MonoBehaviour
     {
         var screenCenter = Camera.current.ViewportToScreenPoint(new Vector3(0.5f, 0.5f));
         var hits = new List<ARRaycastHit>();
-        arOrigin.Raycast(screenCenter, hits, TrackableType.Planes);
+        arOrigin.GetComponent<ARRaycastManager>().Raycast(screenCenter, hits, UnityEngine.XR.ARSubsystems.TrackableType.Planes);
 
         placementPoseIsValid = hits.Count > 0;
         if (placementPoseIsValid)


### PR DESCRIPTION
 original statement:
arOrigin.Raycast(screenCenter, hits, TrackableType.Planes);
leads to a compiler error.
Solution found in the comments section of Getting Started with AR Foundation: https://www.youtube.com/watch?v=Ml2UakwRxjk @ErikNatzke
and Migration Guide: https://docs.unity3d.com/Packages/com.unity.xr.arfoundation@2.0/manual/migration-guide.html